### PR TITLE
Add `tests` feature; make `rand` and `rand_xorshift` deps optional

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,11 @@ jobs:
         with:
           command: test
           args: --verbose --release
+      - name: Run --all-features tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --all-features --verbose --release
 
   no-std:
     name: Check no-std compatibility

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,13 +17,15 @@ edition = "2018"
 [dependencies]
 byteorder = { version = "1", default-features = false }
 ff = { version = "0.7", default-features = false }
-rand = { version = "0.7", default-features = false }
-rand_xorshift = "0.2"
+rand = { version = "0.7", optional = true, default-features = false }
+rand_core = { version = "0.5", default-features = false }
+rand_xorshift = { version = "0.2", optional = true }
 subtle = { version = "2.2.1", default-features = false }
 
 [features]
 default = ["alloc"]
 alloc = []
+tests = ["alloc", "rand", "rand_xorshift"]
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,12 +10,12 @@ use core::fmt;
 use core::iter::Sum;
 use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 use ff::PrimeField;
-use rand::RngCore;
+use rand_core::RngCore;
 use subtle::{Choice, CtOption};
 
 pub mod cofactor;
 pub mod prime;
-#[cfg(feature = "alloc")]
+#[cfg(feature = "tests")]
 pub mod tests;
 
 #[cfg(feature = "alloc")]
@@ -74,7 +74,7 @@ pub trait Group:
     /// this group.
     ///
     /// This function is non-deterministic, and samples from the user-provided RNG.
-    fn random<R: RngCore + ?Sized>(rng: &mut R) -> Self;
+    fn random(rng: impl RngCore) -> Self;
 
     /// Returns the additive identity, also known as the "neutral element".
     fn identity() -> Self;


### PR DESCRIPTION
Closes #10.

Gates the `tests` module along with the `rand` and `rand_xorshift` dependencies on a new `tests` cargo feature. This allows the core library to depend on `rand_core` alone.

Additionally, uses `impl Trait` syntactic sugar for the `RngCore` argument to `randomize` (as discussed in #10).