### PR TITLE
Bump `rand_core` dependency to v0.6; `rand` to v0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,10 @@ edition = "2018"
 
 [dependencies]
 byteorder = { version = "1", optional = true, default-features = false }
-ff = { version = "0.8", default-features = false }
-rand = { version = "0.7", optional = true, default-features = false }
-rand_core = { version = "0.5", default-features = false }
-rand_xorshift = { version = "0.2", optional = true }
+ff = { version = "0.9", default-features = false }
+rand = { version = "0.8", optional = true, default-features = false }
+rand_core = { version = "0.6", default-features = false }
+rand_xorshift = { version = "0.3", optional = true }
 subtle = { version = "2.2.1", default-features = false }
 
 [features]


### PR DESCRIPTION
Closes #15

Depends on: zkcrypto/ff#49