### PR TITLE
Re-export ff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this library adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `group::ff`, which re-exports the `ff` crate to make version-matching easier.
+
 ### Changed
 - MSRV is now 1.51.0.
 - Bumped `ff` to 0.10.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,9 @@
 #[macro_use]
 extern crate alloc;
 
+// Re-export ff to make version-matching easier.
+pub use ff;
+
 use core::fmt;
 use core::iter::Sum;
 use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};


### PR DESCRIPTION
This makes version-matching easier for downstream users.