### PR TITLE
Fix `{Cofactor, Prime}Curve: Mul` bounds

### DIFF
--- a/src/cofactor.rs
+++ b/src/cofactor.rs
@@ -59,7 +59,7 @@ pub trait CofactorCurve:
 {
     type Affine: CofactorCurveAffine<Curve = Self, Scalar = Self::Scalar>
         + Mul<Self::Scalar, Output = Self>
-        + for<'r> Mul<Self::Scalar, Output = Self>;
+        + for<'r> Mul<&'r Self::Scalar, Output = Self>;
 }
 
 /// Affine representation of an elliptic curve point guaranteed to be
@@ -78,7 +78,7 @@ pub trait CofactorCurveAffine:
     + Neg<Output = Self>
     + Mul<<Self as CofactorCurveAffine>::Scalar, Output = <Self as CofactorCurveAffine>::Curve>
     + for<'r> Mul<
-        <Self as CofactorCurveAffine>::Scalar,
+        &'r <Self as CofactorCurveAffine>::Scalar,
         Output = <Self as CofactorCurveAffine>::Curve,
     >
 {

--- a/src/prime.rs
+++ b/src/prime.rs
@@ -13,13 +13,12 @@ pub trait PrimeGroup: Group + GroupEncoding {}
 pub trait PrimeCurve: Curve<AffineRepr = <Self as PrimeCurve>::Affine> + PrimeGroup {
     type Affine: PrimeCurveAffine<Curve = Self, Scalar = Self::Scalar>
         + Mul<Self::Scalar, Output = Self>
-        + for<'r> Mul<Self::Scalar, Output = Self>;
+        + for<'r> Mul<&'r Self::Scalar, Output = Self>;
 }
 
 /// Affine representation of an elliptic curve point guaranteed to be
 /// in the correct prime order subgroup.
-pub trait PrimeCurveAffine:
-    GroupEncoding
+pub trait PrimeCurveAffine: GroupEncoding
     + Copy
     + Clone
     + Sized
@@ -31,7 +30,7 @@ pub trait PrimeCurveAffine:
     + 'static
     + Neg<Output = Self>
     + Mul<<Self as PrimeCurveAffine>::Scalar, Output = <Self as PrimeCurveAffine>::Curve>
-    + for<'r> Mul<<Self as PrimeCurveAffine>::Scalar, Output = <Self as PrimeCurveAffine>::Curve>
+    + for<'r> Mul<&'r <Self as PrimeCurveAffine>::Scalar, Output = <Self as PrimeCurveAffine>::Curve>
 {
     type Scalar: PrimeField;
     type Curve: PrimeCurve<Affine = Self, Scalar = Self::Scalar>;


### PR DESCRIPTION
We had `for<'r>` lifetimes that were going unused, instead of enabling the RHS to be a reference.

Closes zkcrypto/group#22.