### PR TITLE
Revive base field type on Curve trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ pub use ff;
 use core::fmt;
 use core::iter::Sum;
 use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
-use ff::PrimeField;
+use ff::{Field, PrimeField};
 use rand_core::RngCore;
 use subtle::{Choice, CtOption};
 
@@ -96,6 +96,9 @@ pub trait Group:
 pub trait Curve:
     Group + GroupOps<<Self as Curve>::AffineRepr> + GroupOpsOwned<<Self as Curve>::AffineRepr>
 {
+    /// The base field of the elliptic curve.
+    type Base: Field;
+
     /// The affine representation for this elliptic curve.
     type AffineRepr;
 


### PR DESCRIPTION
Curves operate on certain base fields. Sometimes in can be useful to have
a direct reference to which field this is. With the `Base` associate type
you can not get that information.

More concretely this will be used by some GPU code, which needs access to
the information which base field a curve operates on.

BREAKING CHANGE: crates implementing `Curve` need to define the `Base`.

To be even more concrete. I'm working on the multiexp implementation for GPUs.
I'd like to be able to bundle implementations for different fields within one kernel,
hence I name the kernel `<base-field>_<scalar-field>_multiexp`. For that I need
to know which base field the curve has.

There are potential workarounds, but this seems to be the cleanest solution to me.
Updating crates implementing `Curve` is straightforward, I'd be happy to provide PRs
for those if you let me know which ones they are (I know of e.g. `blstrs`).