### PR TITLE
Add `Wnaf` APIs for caching both bases and scalars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this library adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `group::Wnaf` APIs for caching both bases and scalars, for improved many-base
+  many-scalar performance:
+  - `group::FixedWindow`
+  - `group::Wnaf::<FixedWindow<WINDOW_SIZE>, _, _>::{base, scalar, exp}`
 
 ## [0.12.0] - 2022-05-04
 ### Changed

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ pub mod tests;
 #[cfg(feature = "alloc")]
 mod wnaf;
 #[cfg(feature = "alloc")]
-pub use self::wnaf::{Wnaf, WnafGroup};
+pub use self::wnaf::{FixedWindow, Wnaf, WnafGroup};
 
 /// A helper trait for types with a group operation.
 pub trait GroupOps<Rhs = Self, Output = Self>:

--- a/src/wnaf.rs
+++ b/src/wnaf.rs
@@ -349,7 +349,7 @@ impl<B, S: AsMut<Vec<i64>>> Wnaf<usize, B, S> {
     }
 }
 
-/// A window sized that is fixed in the type system.
+/// A window size that is fixed in the type system.
 pub struct FixedWindow<const WINDOW_SIZE: usize>;
 
 impl<G: WnafGroup, const WINDOW_SIZE: usize>


### PR DESCRIPTION
This makes the `n * m` pattern more efficient (w-NAF tables / forms are only computed once for each base / scalar) and has more predictable memory usage (one w-NAF table of the specified window size per base, one w-NAF form of the specified window size per scalar).