### PR TITLE
Replace `Wnaf::{base, scalar}` with `WnafBase` and `WnafScalar`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,9 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 ### Added
-- `group::Wnaf` APIs for caching both bases and scalars, for improved many-base
-  many-scalar performance:
-  - `group::FixedWindow`
-  - `group::Wnaf::<FixedWindow<WINDOW_SIZE>, _, _>::{base, scalar, exp}`
+- `group::{WnafBase, WnafScalar}` structs for caching precomputations of both
+  bases and scalars, for improved many-base many-scalar multiplication
+  performance.
 
 ## [0.12.0] - 2022-05-04
 ### Changed

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ pub mod tests;
 #[cfg(feature = "alloc")]
 mod wnaf;
 #[cfg(feature = "alloc")]
-pub use self::wnaf::{FixedWindow, Wnaf, WnafGroup};
+pub use self::wnaf::{Wnaf, WnafBase, WnafGroup, WnafScalar};
 
 /// A helper trait for types with a group operation.
 pub trait GroupOps<Rhs = Self, Output = Self>:

--- a/src/wnaf.rs
+++ b/src/wnaf.rs
@@ -369,7 +369,7 @@ impl<F: PrimeField, const WINDOW_SIZE: usize> WnafScalar<F, WINDOW_SIZE> {
     pub fn new(scalar: &F) -> Self {
         let mut wnaf = vec![];
 
-        // Compute the wNAF form of the scalar.
+        // Compute the w-NAF form of the scalar.
         wnaf_form(&mut wnaf, scalar.to_repr(), WINDOW_SIZE);
 
         WnafScalar {
@@ -385,7 +385,7 @@ impl<F: PrimeField, const WINDOW_SIZE: usize> WnafScalar<F, WINDOW_SIZE> {
 /// This struct is designed for usage patterns that have long-term cached bases and/or
 /// scalars, or [Cartesian products] of bases and scalars. The [`Wnaf`] API enables one or
 /// the other to be cached, but requires either the base window tables or the scalar w-NAF
-/// forms to be computed repeatedly on-the-fly, which can become a significant performance
+/// forms to be computed repeatedly on the fly, which can become a significant performance
 /// issue for some use cases.
 ///
 /// `WnafBase` and [`WnafScalar`] enable an alternative trade-off: by fixing the window
@@ -423,7 +423,7 @@ impl<G: Group, const WINDOW_SIZE: usize> WnafBase<G, WINDOW_SIZE> {
     pub fn new(base: G) -> Self {
         let mut table = vec![];
 
-        // Compute a wNAF table for the provided base and window size.
+        // Compute a window table for the provided base and window size.
         wnaf_table(&mut table, base, WINDOW_SIZE);
 
         WnafBase { table }


### PR DESCRIPTION
This change decouples the w-NAF form of the scalar from the specific `Group` implementation, which enables reusing a scalar for both general and subgroup scalar multiplication.