### PR TITLE
Add `memuse::DynamicUsage` impls for w-NAF structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this library adheres to Rust's notion of
 - `group::{WnafBase, WnafScalar}` structs for caching precomputations of both
   bases and scalars, for improved many-base many-scalar multiplication
   performance.
+- `impl memuse::DynamicUsage for group::{Wnaf WnafBase, WnafScalar}`, behind the
+  new `wnaf-memuse` feature flag, to enable the heap usage of these types to be
+  measured at runtime.
 
 ## [0.12.0] - 2022-05-04
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,10 +21,14 @@ rand_core = { version = "0.6", default-features = false }
 rand_xorshift = { version = "0.3", optional = true }
 subtle = { version = "2.2.1", default-features = false }
 
+# Crate for exposing the dynamic memory usage of the w-NAF structs.
+memuse = { version = "0.2", optional = true }
+
 [features]
 default = ["alloc"]
 alloc = []
 tests = ["alloc", "rand", "rand_xorshift"]
+wnaf-memuse = ["alloc", "memuse"]
 
 [badges]
 maintenance = { status = "actively-developed" }


### PR DESCRIPTION
This enables the heap usage of these types to be measured at runtime.