### PR TITLE
Refactor identity methods into `Identity` trait

### DIFF
--- a/src/cofactor.rs
+++ b/src/cofactor.rs
@@ -3,6 +3,7 @@ use core::ops::{Mul, Neg};
 use ff::PrimeField;
 use subtle::{Choice, CtOption};
 
+use crate::Identity;
 use crate::{prime::PrimeGroup, Curve, Group, GroupEncoding, GroupOps, GroupOpsOwned};
 
 /// This trait represents an element of a cryptographic group with a large prime-order
@@ -66,6 +67,7 @@ pub trait CofactorCurve:
 /// in the correct prime order subgroup.
 pub trait CofactorCurveAffine:
     GroupEncoding
+    + Identity
     + Copy
     + Clone
     + Sized
@@ -85,15 +87,8 @@ pub trait CofactorCurveAffine:
     type Scalar: PrimeField;
     type Curve: CofactorCurve<Affine = Self, Scalar = Self::Scalar>;
 
-    /// Returns the additive identity.
-    fn identity() -> Self;
-
     /// Returns a fixed generator of unknown exponent.
     fn generator() -> Self;
-
-    /// Determines if this point represents the point at infinity; the
-    /// additive identity.
-    fn is_identity(&self) -> Choice;
 
     /// Converts this element to its curve representation.
     fn to_curve(&self) -> Self::Curve;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,8 @@ impl<T, Rhs, Output> ScalarMulOwned<Rhs, Output> for T where T: for<'r> ScalarMu
 
 /// This trait represents an element of a cryptographic group.
 pub trait Group:
-    Clone
+    Identity
+    + Clone
     + Copy
     + fmt::Debug
     + Eq
@@ -78,14 +79,8 @@ pub trait Group:
     /// This function is non-deterministic, and samples from the user-provided RNG.
     fn random(rng: impl RngCore) -> Self;
 
-    /// Returns the additive identity, also known as the "neutral element".
-    fn identity() -> Self;
-
     /// Returns a fixed generator of the prime-order subgroup.
     fn generator() -> Self;
-
-    /// Determines if this point is the identity.
-    fn is_identity(&self) -> Choice;
 
     /// Doubles this element.
     #[must_use]
@@ -171,4 +166,14 @@ pub trait UncompressedEncoding: Sized {
     /// Converts this element into its uncompressed encoding, so long as it's not
     /// the point at infinity.
     fn to_uncompressed(&self) -> Self::Uncompressed;
+}
+
+/// Obtain or determine the identity point.
+pub trait Identity: Sized {
+    /// Returns the additive identity.
+    fn identity() -> Self;
+
+    /// Determines if this point represents the point at infinity; the
+    /// additive identity.
+    fn is_identity(&self) -> Choice;
 }

--- a/src/prime.rs
+++ b/src/prime.rs
@@ -1,9 +1,8 @@
 use core::fmt;
 use core::ops::{Mul, Neg};
 use ff::PrimeField;
-use subtle::Choice;
 
-use crate::{Curve, Group, GroupEncoding};
+use crate::{Curve, Group, GroupEncoding, Identity};
 
 /// This trait represents an element of a prime-order cryptographic group.
 pub trait PrimeGroup: Group + GroupEncoding {}
@@ -19,6 +18,7 @@ pub trait PrimeCurve: Curve<AffineRepr = <Self as PrimeCurve>::Affine> + PrimeGr
 /// Affine representation of an elliptic curve point guaranteed to be
 /// in the correct prime order subgroup.
 pub trait PrimeCurveAffine: GroupEncoding
+    + Identity
     + Copy
     + Clone
     + Sized
@@ -35,15 +35,8 @@ pub trait PrimeCurveAffine: GroupEncoding
     type Scalar: PrimeField;
     type Curve: PrimeCurve<Affine = Self, Scalar = Self::Scalar>;
 
-    /// Returns the additive identity.
-    fn identity() -> Self;
-
     /// Returns a fixed generator of unknown exponent.
     fn generator() -> Self;
-
-    /// Determines if this point represents the point at infinity; the
-    /// additive identity.
-    fn is_identity(&self) -> Choice;
 
     /// Converts this element to its curve representation.
     fn to_curve(&self) -> Self::Curve;

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -7,7 +7,7 @@ use rand_xorshift::XorShiftRng;
 use crate::{
     prime::{PrimeCurve, PrimeCurveAffine},
     wnaf::WnafGroup,
-    GroupEncoding, UncompressedEncoding,
+    GroupEncoding, Identity, UncompressedEncoding,
 };
 
 pub fn curve_tests<G: PrimeCurve>() {


### PR DESCRIPTION
Introduces a new trait: `Identity`.
Moving all `identity()` and `is_identity()` methods to it. This enables generalizing over different point types when the identity point is needed.

This is a breaking change.
Fixes #41.