### PR TITLE
Add `Group::mul_by_generator`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,6 +90,12 @@ pub trait Group:
     /// Doubles this element.
     #[must_use]
     fn double(&self) -> Self;
+
+    /// Multiply by the generator of the prime-order subgroup.
+    #[must_use]
+    fn mul_by_generator(scalar: &Self::Scalar) -> Self {
+        Self::generator() * scalar
+    }
 }
 
 /// Efficient representation of an elliptic curve point guaranteed.


### PR DESCRIPTION
Adds a provided method to the `Group` trait for performing multiplication by the generator.

The use case is overriding this method in the event that precomputed scalar multiplication tables are available, which may be conditional depending on crate features like `alloc` or feature-gated static precomputed tables.