### PR TITLE
fix: typos in documentation files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this library adheres to Rust's notion of
 - `group::{WnafBase, WnafScalar}` structs for caching precomputations of both
   bases and scalars, for improved many-base many-scalar multiplication
   performance.
-- `impl memuse::DynamicUsage for group::{Wnaf WnafBase, WnafScalar}`, behind the
+- `impl memuse::DynamicUsage for group::{Wnaf, WnafBase, WnafScalar}`, behind the
   new `wnaf-memuse` feature flag, to enable the heap usage of these types to be
   measured at runtime.
 


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
In the section ## [0.12.1], the line:
`impl memuse::DynamicUsage for group::{Wnaf WnafBase, WnafScalar}`, is likely a small formatting mistake — there should not be an extra space between `Wnaf` and `WnafBase`. 
The correct version is: `impl memuse::DynamicUsage for group::{Wnaf, WnafBase, WnafScalar}`

Please review the changes and let me know if any additional changes are needed.