### PR TITLE
require `Field` instead of `PrimeField` for `Group`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+### Changed
+
+- `Group::Scalar` is now bound by `ff::Field` instead of `ff::PrimeField`.
+
 ## [0.13.0] - 2022-12-06
 ### Changed
 - Bumped `ff` to `0.13`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,7 +70,7 @@ pub trait Group:
     + ScalarMulOwned<<Self as Group>::Scalar>
 {
     /// Scalars modulo the order of this group's scalar field.
-    type Scalar: PrimeField;
+    type Scalar: Field;
 
     /// Returns an element chosen uniformly at random from the non-identity elements of
     /// this group.


### PR DESCRIPTION
Implements #65.