### PR TITLE
Add `GroupCanonicalEncoding`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,6 +174,19 @@ pub trait GroupEncoding: Sized {
     fn to_bytes(&self) -> Self::Repr;
 }
 
+/// `GroupEncoding` with an additional bound that byte representations be canonical.
+pub trait GroupCanonicalEncoding: Sized + GroupEncoding {
+    /// Attempts to deserialize a group element from its canonical encoding.
+    ///
+    /// For any returned point, it will be returned if and only if the exact argument `bytes` was
+    /// passed into this function. This implies checking the coordinate(s) were reduced, and flags,
+    /// sign bits, etc were minimal.
+    fn from_canonical_bytes(bytes: &Self::Repr) -> CtOption<Self>;
+
+    /// Converts this element into its canonical byte encoding.
+    fn to_canonical_bytes(&self) -> Self::Repr;
+}
+
 /// Affine representation of a point on an elliptic curve that has a defined uncompressed
 /// encoding.
 pub trait UncompressedEncoding: Sized {


### PR DESCRIPTION
`PrimeField::from_repr` required the representation of an element be canonical. `GroupEncoding::from_bytes` (unfortunately) did not, and implementations have not always required points be canonical. Notably, `curve25519-dalek` does not (https://github.com/dalek-cryptography/curve25519-dalek/issues/380).

Instead of modifying `GroupEncoding` to state representations must be canonical, which may be a debated change and would be easily overlooked when updating, a new trait is added. This shouldn't be invasive at all, yet allows callers to require a canonical encoding and implementations to declare they offer one.

I'm unaware of any library whose `to_bytes` isn't canonical, yet I added a `to_canonical_bytes` for parity with `from_canonical_bytes`. `from_bytes_unchecked` is left without a counterpart as the entire point of this trait is to perform a canonicity check. Descending from `GroupEncoding` (necessary to access `Repr` via) allows the original `from_bytes_unchecked` to still be used.

This is necessary as currently, within a generic setting, a bespoke marker trait must be defined and manually implemented, or callers must assume `to_bytes` will be canonical and after decoding, re-encode to check for equivalency. This generally incurs a field inversion which is quite expensive.

I'm aware an RFC process is defined, but it isn't required for anything which isn't invasive. I believe this is sufficiently not invasive to scrape by. Please correct me if I'm wrong.