### PR TITLE
wnaf: support windows of size 64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,6 @@ jobs:
       - uses: actions/checkout@v4
       - run: cargo fetch
       # Requires #![deny(rustdoc::broken_intra_doc_links)] in crates.
-      - run: sudo apt-get -y install libfontconfig1-dev
       - name: Check intra-doc links
         run: cargo doc --all-features --document-private-items
 

--- a/src/wnaf.rs
+++ b/src/wnaf.rs
@@ -104,8 +104,8 @@ pub(crate) fn wnaf_form<S: AsRef<[u8]>>(wnaf: &mut Vec<i64>, c: S, window: usize
     // Initialise the current and next limb buffers.
     let mut limbs = LimbBuffer::new(c.as_ref());
 
-    let width = 1u64 << window;
-    let window_mask = width - 1;
+    let width = 1u128 << window;
+    let window_mask = (width - 1) as u64; // max `width` is `1 << 64 == u64::MAX + 1`
 
     let mut pos = 0;
     let mut carry = 0;
@@ -133,12 +133,13 @@ pub(crate) fn wnaf_form<S: AsRef<[u8]>>(wnaf: &mut Vec<i64>, c: S, window: usize
             wnaf.push(0);
             pos += 1;
         } else {
-            wnaf.push(if window_val < width / 2 {
+            // max `width` is `1 << 64`, which becomes `1 << 63` when divided by 2, which fits `u64`
+            wnaf.push(if window_val < (width / 2) as u64 {
                 carry = 0;
                 window_val as i64
             } else {
                 carry = 1;
-                (window_val as i64).wrapping_sub(width as i64)
+                (window_val as i128).wrapping_sub(width as i128) as i64
             });
             wnaf.extend(iter::repeat(0).take(window - 1));
             pos += window;

--- a/src/wnaf.rs
+++ b/src/wnaf.rs
@@ -104,8 +104,9 @@ pub(crate) fn wnaf_form<S: AsRef<[u8]>>(wnaf: &mut Vec<i64>, c: S, window: usize
     // Initialise the current and next limb buffers.
     let mut limbs = LimbBuffer::new(c.as_ref());
 
-    let width = 1u128 << window;
-    let window_mask = (width - 1) as u64; // max `width` is `1 << 64 == u64::MAX + 1`
+    let width_div_2 = 1u64 << (window - 1); // window is asserted `2..=64` above
+    let width = (width_div_2 as i128) * 2; // for conditionally subtracting from `window_val`
+    let window_mask = width_div_2 | (width_div_2 - 1); // fill in 1s for all the lower 0 bits
 
     let mut pos = 0;
     let mut carry = 0;
@@ -133,13 +134,12 @@ pub(crate) fn wnaf_form<S: AsRef<[u8]>>(wnaf: &mut Vec<i64>, c: S, window: usize
             wnaf.push(0);
             pos += 1;
         } else {
-            // max `width` is `1 << 64`, which becomes `1 << 63` when divided by 2, which fits `u64`
-            wnaf.push(if window_val < (width / 2) as u64 {
+            wnaf.push(if window_val < width_div_2 {
                 carry = 0;
                 window_val as i64
             } else {
                 carry = 1;
-                (window_val as i128).wrapping_sub(width as i128) as i64
+                ((window_val as i128) - width) as i64
             });
             wnaf.extend(iter::repeat(0).take(window - 1));
             pos += window;


### PR DESCRIPTION
Followup to #46 which attempted to change an assertion for the window size from `<= 64` to `< 64`, which was in response to the `width` type being `u64` and its value computed as `1 << window`, which would overflow a `u64`.

This means `width` needs an extra bit, so this promotes it to a `u128` while keeping any variables that can remain `u64` as they were.