### PR TITLE
Fix `wnaf_table` overallocation

### DIFF
--- a/src/wnaf.rs
+++ b/src/wnaf.rs
@@ -15,13 +15,18 @@ pub trait WnafGroup: Group {
 }
 
 /// Replaces the contents of `table` with a w-NAF window table for the given window size.
+///
+/// For a window of size `w`, non-zero wNAF digits are odd and have magnitude at most
+/// `2^(w-1) - 1`. The table is indexed by `|digit| / 2`, so the required size is
+/// `(2^(w-1) - 1) / 2 + 1 = 2^(w-2)` entries.
 pub(crate) fn wnaf_table<G: Group>(table: &mut Vec<G>, mut base: G, window: usize) {
+    let table_len = 1 << (window - 2);
     table.truncate(0);
-    table.reserve(1 << (window - 1));
+    table.reserve(table_len);
 
     let dbl = base.double();
 
-    for _ in 0..(1 << (window - 1)) {
+    for _ in 0..table_len {
         table.push(base);
         base.add_assign(&dbl);
     }


### PR DESCRIPTION
For window size `w`, wNAF digits have max magnitude `2^(w-1) - 1`. The table is indexed by `|digit| / 2`, so the maximum index is `(2^(w-1) - 1) / 2 = 2^(w-2) - 1`, requiring `2^(w-2)` entries.

The previous `2^(w-1)` allocation computed twice as many odd multiples as needed, wasting point additions during table setup.

## Benchmark

Ran the `RustCrypto/k256` benches and gave around 20% improvements for hot paths, albeit on a noisy system.

``` 
schnorr/verify    time:   [52.109 µs 52.232 µs 52.374 µs]
                             change: [−26.395% −23.813% −21.156%] (p = 0.00 < 0.05)
                             Performance has improved.
 Found 28 outliers among 200 measurements (14.00%)
  28 (14.00%) high mild
```

## Correctness

In an effort to make review easier, I have also demonstrated a [Lean proof](https://github.com/42Pupusas/elliptic-curve-proofs/blob/mera/K256Proofs/K256Proofs/WnafTableBounds.lean) verifying the above claims. 