### PR TITLE
Use canonical LE byte representation from upstream ff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,8 @@ version = 3
 
 [[package]]
 name = "ff"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
+version = "0.13.1"
+source = "git+https://github.com/TalDerei/ff.git?branch=le-serialization#2db5b47866f9ff76f8b9873074ecac65a083e3ad"
 dependencies = [
  "rand_core",
  "subtle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ homepage = "https://github.com/zkcrypto/group"
 repository = "https://github.com/zkcrypto/group"
 
 [dependencies]
-ff = { version = "0.13", default-features = false }
+ff = { git = "https://github.com/TalDerei/ff.git", branch = "le-serialization", default-features = false }
 rand = { version = "0.8", optional = true, default-features = false }
 rand_core = { version = "0.6", default-features = false }
 rand_xorshift = { version = "0.3", optional = true }

--- a/src/wnaf.rs
+++ b/src/wnaf.rs
@@ -309,7 +309,7 @@ impl<G: WnafGroup> Wnaf<(), Vec<G>, Vec<i64>> {
         let window_size = 4;
 
         // Compute the wNAF form of the scalar.
-        wnaf_form(&mut self.scalar, scalar.to_repr(), window_size);
+        wnaf_form(&mut self.scalar, scalar.to_le_repr(), window_size);
 
         // Return a Wnaf object that mutably borrows the base storage location, but
         // immutably borrows the computed wNAF form scalar location.
@@ -387,7 +387,7 @@ impl<B, S: AsMut<Vec<i64>>> Wnaf<usize, B, S> {
     where
         B: AsRef<[G]>,
     {
-        wnaf_form(self.scalar.as_mut(), scalar.to_repr(), self.window_size);
+        wnaf_form(self.scalar.as_mut(), scalar.to_le_repr(), self.window_size);
         wnaf_exp(self.base.as_ref(), self.scalar.as_mut())
     }
 }
@@ -422,7 +422,7 @@ impl<F: PrimeField, const WINDOW_SIZE: usize> WnafScalar<F, WINDOW_SIZE> {
         let mut wnaf = vec![];
 
         // Compute the w-NAF form of the scalar.
-        wnaf_form(&mut wnaf, scalar.to_repr(), WINDOW_SIZE);
+        wnaf_form(&mut wnaf, scalar.to_le_repr(), WINDOW_SIZE);
 
         WnafScalar {
             wnaf,


### PR DESCRIPTION
References https://github.com/zkcrypto/group/issues/78. [ff 0.14.0](https://github.com/zkcrypto/ff/pull/130) to ship with `to_le_repr` included, then bump group's ff version.