### PR TITLE
Fix: append final carry after wnaf_form loop

### DIFF
--- a/src/wnaf.rs
+++ b/src/wnaf.rs
@@ -144,6 +144,10 @@ pub(crate) fn wnaf_form<S: AsRef<[u8]>>(wnaf: &mut Vec<i64>, c: S, window: usize
             pos += window;
         }
     }
+
+    if carry > 0 {
+        wnaf.push(carry as i64);
+    }
 }
 
 /// Performs w-NAF exponentiation with the provided window table and w-NAF form scalar.
@@ -502,5 +506,17 @@ impl<G: Group, const WINDOW_SIZE: usize> Mul<&WnafScalar<G::Scalar, WINDOW_SIZE>
 
     fn mul(self, rhs: &WnafScalar<G::Scalar, WINDOW_SIZE>) -> Self::Output {
         wnaf_exp(&self.table, &rhs.wnaf)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::wnaf_form;
+
+    #[test]
+    fn wnaf_form_keeps_final_carry() {
+        let mut wnaf = vec![];
+        wnaf_form(&mut wnaf, [0xff], 4);
+        assert_eq!(wnaf, vec![-1, 0, 0, 0, 0, 0, 0, 0, 1]);
     }
 }


### PR DESCRIPTION
## Summary
Fixes `wnaf_form` dropping a final carry after processing the last input bit.
For window size `w`, a negative digit sets `carry = 1`. If that carry remains after `pos >= bit_len`, the previous code terminates without emitting it, so the produced WNAF digits reconstructed a different scalar. 

For example, with `window = 4`, `[0xff]` encoded as `[-1, 0, 0, 0, 0, 0, 0, 0]`, which evaluates to `-1` instead of `255`.
This appends the final carry when present and adds a regression test for `[0xff]`, whose correct WNAF is `[-1, 0, 0, 0, 0, 0, 0, 0, 1]`.

## Test
`cargo test wnaf_form_keeps_final_carry`